### PR TITLE
Add basic QNX Neutrino support

### DIFF
--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(solarish, target_os = "haiku")))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "nto")))]
 use super::types::FileType;
 use crate::backend::c;
 use crate::backend::conv::owned_fd;
@@ -11,6 +11,7 @@ use crate::fs::{fcntl_getfl, fstat, openat, Mode, OFlags, Stat};
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 use crate::fs::{fstatfs, StatFs};
 #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "wasi")))]
@@ -124,6 +125,7 @@ impl Dir {
         target_os = "netbsd",
         target_os = "redox",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     #[inline]
     pub fn statfs(&self) -> io::Result<StatFs> {
@@ -200,7 +202,7 @@ impl DirEntry {
     }
 
     /// Returns the type of this directory entry.
-    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku", target_os = "nto")))]
     #[inline]
     pub fn file_type(&self) -> FileType {
         FileType::from_dirent_d_type(self.d_type)

--- a/src/backend/libc/fs/dir.rs
+++ b/src/backend/libc/fs/dir.rs
@@ -95,7 +95,12 @@ impl Dir {
                 check_dirent_layout(dirent);
 
                 let result = DirEntry {
-                    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku")))]
+                    #[cfg(not(any(
+                        solarish,
+                        target_os = "aix",
+                        target_os = "haiku",
+                        target_os = "nto",
+                    )))]
                     d_type: dirent.d_type,
 
                     #[cfg(not(any(freebsdlike, netbsdlike)))]
@@ -182,7 +187,7 @@ impl fmt::Debug for Dir {
 /// `struct dirent`
 #[derive(Debug)]
 pub struct DirEntry {
-    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(solarish, target_os = "aix", target_os = "haiku", target_os = "nto")))]
     d_type: u8,
 
     #[cfg(not(any(freebsdlike, netbsdlike)))]

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -292,6 +292,7 @@ bitflags! {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "netbsd",
+            target_os = "nto",
         ))]
         const DIRECT = c::O_DIRECT;
 

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -292,7 +292,6 @@ bitflags! {
             target_os = "freebsd",
             target_os = "fuchsia",
             target_os = "netbsd",
-            target_os = "nto",
         ))]
         const DIRECT = c::O_DIRECT;
 

--- a/src/backend/libc/fs/types.rs
+++ b/src/backend/libc/fs/types.rs
@@ -478,7 +478,7 @@ impl FileType {
     }
 
     /// Construct a `FileType` from the `d_type` field of a `c::dirent`.
-    #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox")))]
+    #[cfg(not(any(solarish, target_os = "haiku", target_os = "redox", target_os = "nto")))]
     #[inline]
     pub(crate) const fn from_dirent_d_type(d_type: u8) -> Self {
         match d_type {
@@ -720,6 +720,7 @@ bitflags! {
             target_os = "aix",
             target_os = "haiku",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const KEEP_SIZE = c::FALLOC_FL_KEEP_SIZE;
         /// `FALLOC_FL_PUNCH_HOLE`
@@ -728,6 +729,7 @@ bitflags! {
             target_os = "aix",
             target_os = "haiku",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const PUNCH_HOLE = c::FALLOC_FL_PUNCH_HOLE;
         /// `FALLOC_FL_NO_HIDE_STALE`
@@ -739,6 +741,7 @@ bitflags! {
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const NO_HIDE_STALE = c::FALLOC_FL_NO_HIDE_STALE;
         /// `FALLOC_FL_COLLAPSE_RANGE`
@@ -748,6 +751,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "emscripten",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const COLLAPSE_RANGE = c::FALLOC_FL_COLLAPSE_RANGE;
         /// `FALLOC_FL_ZERO_RANGE`
@@ -757,6 +761,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "emscripten",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const ZERO_RANGE = c::FALLOC_FL_ZERO_RANGE;
         /// `FALLOC_FL_INSERT_RANGE`
@@ -766,6 +771,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "emscripten",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const INSERT_RANGE = c::FALLOC_FL_INSERT_RANGE;
         /// `FALLOC_FL_UNSHARE_RANGE`
@@ -775,6 +781,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "emscripten",
             target_os = "wasi",
+            target_os = "nto",
         )))]
         const UNSHARE_RANGE = c::FALLOC_FL_UNSHARE_RANGE;
     }
@@ -907,6 +914,7 @@ pub struct Stat {
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 #[allow(clippy::module_name_repetitions)]
 pub type StatFs = c::statfs;

--- a/src/backend/libc/io/errno.rs
+++ b/src/backend/libc/io/errno.rs
@@ -164,6 +164,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const DOTDOT: Self = Self(c::EDOTDOT);
     /// `EDQUOT`
@@ -194,6 +195,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "redox",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const HWPOISON: Self = Self(c::EHWPOISON);
     /// `EIDRM`
@@ -235,6 +237,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const ISNAM: Self = Self(c::EISNAM);
     /// `EKEYEXPIRED`
@@ -245,6 +248,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const KEYEXPIRED: Self = Self(c::EKEYEXPIRED);
     /// `EKEYREJECTED`
@@ -255,6 +259,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const KEYREJECTED: Self = Self(c::EKEYREJECTED);
     /// `EKEYREVOKED`
@@ -265,6 +270,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const KEYREVOKED: Self = Self(c::EKEYREVOKED);
     /// `EL2HLT`
@@ -337,6 +343,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const MEDIUMTYPE: Self = Self(c::EMEDIUMTYPE);
     /// `EMFILE`
@@ -359,6 +366,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const NAVAIL: Self = Self(c::ENAVAIL);
     /// `ENEEDAUTH`
@@ -416,6 +424,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const NOKEY: Self = Self(c::ENOKEY);
     /// `ENOLCK`
@@ -432,6 +441,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const NOMEDIUM: Self = Self(c::ENOMEDIUM);
     /// `ENOMEM`
@@ -508,6 +518,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const NOTNAM: Self = Self(c::ENOTNAM);
     /// `ENOTRECOVERABLE`
@@ -598,6 +609,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const REMOTEIO: Self = Self(c::EREMOTEIO);
     /// `ERESTART`
@@ -613,6 +625,7 @@ impl Errno {
         target_os = "haiku",
         target_os = "redox",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const RFKILL: Self = Self(c::ERFKILL);
     /// `EROFS`
@@ -676,6 +689,7 @@ impl Errno {
         target_os = "aix",
         target_os = "haiku",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     pub const UCLEAN: Self = Self(c::EUCLEAN);
     /// `EUNATCH`

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -85,7 +85,12 @@ pub(crate) fn writev(fd: BorrowedFd<'_>, bufs: &[IoSlice]) -> io::Result<usize> 
     }
 }
 
-#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "solaris")))]
+#[cfg(not(any(
+    target_os = "haiku",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "nto"
+)))]
 pub(crate) fn preadv(
     fd: BorrowedFd<'_>,
     bufs: &mut [IoSliceMut],
@@ -103,7 +108,12 @@ pub(crate) fn preadv(
     }
 }
 
-#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "solaris")))]
+#[cfg(not(any(
+    target_os = "haiku",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "nto"
+)))]
 pub(crate) fn pwritev(fd: BorrowedFd<'_>, bufs: &[IoSlice], offset: u64) -> io::Result<usize> {
     // Silently cast; we'll get `EINVAL` if the value is negative.
     let offset = offset as i64;
@@ -333,6 +343,7 @@ pub(crate) fn dup2(fd: BorrowedFd<'_>, new: &mut OwnedFd) -> io::Result<()> {
     target_os = "haiku",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 pub(crate) fn dup3(fd: BorrowedFd<'_>, new: &mut OwnedFd, flags: DupFlags) -> io::Result<()> {
     unsafe {

--- a/src/backend/libc/io/syscalls.rs
+++ b/src/backend/libc/io/syscalls.rs
@@ -10,7 +10,7 @@ use crate::backend::conv::{
 };
 use crate::backend::{c, MAX_IOV};
 use crate::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
-#[cfg(not(any(target_os = "aix", target_os = "wasi")))]
+#[cfg(not(any(target_os = "aix", target_os = "wasi", target_os = "nto")))]
 use crate::io::DupFlags;
 #[cfg(linux_kernel)]
 use crate::io::ReadWriteFlags;

--- a/src/backend/libc/pipe/syscalls.rs
+++ b/src/backend/libc/pipe/syscalls.rs
@@ -25,7 +25,13 @@ pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     }
 }
 
-#[cfg(not(any(apple, target_os = "aix", target_os = "haiku", target_os = "wasi")))]
+#[cfg(not(any(
+    apple,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "wasi",
+    target_os = "nto",
+)))]
 pub(crate) fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {
     unsafe {
         let mut result = MaybeUninit::<[OwnedFd; 2]>::uninit();

--- a/src/backend/libc/pipe/types.rs
+++ b/src/backend/libc/pipe/types.rs
@@ -18,6 +18,7 @@ bitflags! {
             target_os = "haiku",
             target_os = "openbsd",
             target_os = "redox",
+            target_os = "nto",
         )))]
         const DIRECT = c::O_DIRECT;
         /// `O_NONBLOCK`

--- a/src/backend/libc/process/types.rs
+++ b/src/backend/libc/process/types.rs
@@ -56,7 +56,8 @@ pub enum Resource {
     #[cfg(not(target_os = "haiku"))]
     Core = c::RLIMIT_CORE as c::c_int,
     /// `RLIMIT_RSS`
-    #[cfg(not(any(apple, solarish, target_os = "haiku")))]
+    /// QNX Neutrino (nto): Use RLIMIT_AS instead (same value)
+    #[cfg(not(any(apple, solarish, target_os = "haiku", target_os = "nto")))]
     Rss = c::RLIMIT_RSS as c::c_int,
     /// `RLIMIT_NPROC`
     #[cfg(not(any(solarish, target_os = "haiku")))]
@@ -70,19 +71,49 @@ pub enum Resource {
     #[cfg(not(target_os = "openbsd"))]
     As = c::RLIMIT_AS as c::c_int,
     /// `RLIMIT_LOCKS`
-    #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        solarish,
+        target_os = "aix",
+        target_os = "haiku",
+        target_os = "nto",
+    )))]
     Locks = c::RLIMIT_LOCKS as c::c_int,
     /// `RLIMIT_SIGPENDING`
-    #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        solarish,
+        target_os = "aix",
+        target_os = "haiku",
+        target_os = "nto",
+    )))]
     Sigpending = c::RLIMIT_SIGPENDING as c::c_int,
     /// `RLIMIT_MSGQUEUE`
-    #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        solarish,
+        target_os = "aix",
+        target_os = "haiku",
+        target_os = "nto",
+    )))]
     Msgqueue = c::RLIMIT_MSGQUEUE as c::c_int,
     /// `RLIMIT_NICE`
-    #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        solarish,
+        target_os = "aix",
+        target_os = "haiku",
+        target_os = "nto",
+    )))]
     Nice = c::RLIMIT_NICE as c::c_int,
     /// `RLIMIT_RTPRIO`
-    #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+    #[cfg(not(any(
+        bsd,
+        solarish,
+        target_os = "aix",
+        target_os = "haiku",
+        target_os = "nto",
+    )))]
     Rtprio = c::RLIMIT_RTPRIO as c::c_int,
     /// `RLIMIT_RTTIME`
     #[cfg(not(any(
@@ -92,6 +123,7 @@ pub enum Resource {
         target_os = "android",
         target_os = "emscripten",
         target_os = "haiku",
+        target_os = "nto",
     )))]
     Rttime = c::RLIMIT_RTTIME as c::c_int,
 }

--- a/src/backend/libc/termios/syscalls.rs
+++ b/src/backend/libc/termios/syscalls.rs
@@ -175,13 +175,13 @@ pub(crate) fn cfgetispeed(termios: &Termios) -> Speed {
     unsafe { c::cfgetispeed(termios) }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "nto")))]
 #[inline]
 pub(crate) fn cfmakeraw(termios: &mut Termios) {
     unsafe { c::cfmakeraw(termios) }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "nto")))]
 #[inline]
 pub(crate) fn cfsetospeed(termios: &mut Termios, speed: Speed) -> io::Result<()> {
     unsafe { ret(c::cfsetospeed(termios, speed)) }
@@ -193,7 +193,7 @@ pub(crate) fn cfsetispeed(termios: &mut Termios, speed: Speed) -> io::Result<()>
     unsafe { ret(c::cfsetispeed(termios, speed)) }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "nto")))]
 #[inline]
 pub(crate) fn cfsetspeed(termios: &mut Termios, speed: Speed) -> io::Result<()> {
     unsafe { ret(c::cfsetspeed(termios, speed)) }

--- a/src/backend/libc/termios/types.rs
+++ b/src/backend/libc/termios/types.rs
@@ -127,7 +127,13 @@ pub const VTIME: usize = c::VTIME as usize;
 pub const VMIN: usize = c::VMIN as usize;
 
 /// `VSWTC`
-#[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+#[cfg(not(any(
+    bsd,
+    solarish,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "nto",
+)))]
 pub const VSWTC: usize = c::VSWTC as usize;
 
 /// `VSTART`
@@ -465,7 +471,7 @@ pub const B57600: Speed = c::B57600;
 pub const B115200: Speed = c::B115200;
 
 /// `B230400`
-#[cfg(not(target_os = "aix"))]
+#[cfg(not(any(target_os = "aix", target_os = "nto")))]
 pub const B230400: Speed = c::B230400;
 
 /// `B460800`
@@ -474,16 +480,29 @@ pub const B230400: Speed = c::B230400;
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "nto",
 )))]
 pub const B460800: Speed = c::B460800;
 
 /// `B500000`
-#[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+#[cfg(not(any(
+    bsd,
+    solarish,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "nto",
+)))]
 pub const B500000: Speed = c::B500000;
 
 /// `B576000`
-#[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+#[cfg(not(any(
+    bsd,
+    solarish,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "nto",
+)))]
 pub const B576000: Speed = c::B576000;
 
 /// `B921600`
@@ -492,24 +511,49 @@ pub const B576000: Speed = c::B576000;
     target_os = "aix",
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "nto",
 )))]
 pub const B921600: Speed = c::B921600;
 
 /// `B1000000`
-#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+#[cfg(not(any(
+    bsd,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "solaris",
+    target_os = "nto",
+)))]
 pub const B1000000: Speed = c::B1000000;
 
 /// `B1152000`
-#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+#[cfg(not(any(
+    bsd,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "solaris",
+    target_os = "nto",
+)))]
 pub const B1152000: Speed = c::B1152000;
 
 /// `B1500000`
-#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+#[cfg(not(any(
+    bsd,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "solaris",
+    target_os = "nto",
+)))]
 pub const B1500000: Speed = c::B1500000;
 
 /// `B2000000`
-#[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+#[cfg(not(any(
+    bsd,
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "solaris",
+    target_os = "nto",
+)))]
 pub const B2000000: Speed = c::B2000000;
 
 /// `B2500000`
@@ -520,6 +564,7 @@ pub const B2000000: Speed = c::B2000000;
     target_os = "aix",
     target_os = "haiku",
     target_os = "solaris",
+    target_os = "nto",
 )))]
 pub const B2500000: Speed = c::B2500000;
 
@@ -531,6 +576,7 @@ pub const B2500000: Speed = c::B2500000;
     target_os = "aix",
     target_os = "haiku",
     target_os = "solaris",
+    target_os = "nto",
 )))]
 pub const B3000000: Speed = c::B3000000;
 
@@ -542,6 +588,7 @@ pub const B3000000: Speed = c::B3000000;
     target_os = "aix",
     target_os = "haiku",
     target_os = "solaris",
+    target_os = "nto",
 )))]
 pub const B3500000: Speed = c::B3500000;
 
@@ -553,6 +600,7 @@ pub const B3500000: Speed = c::B3500000;
     target_os = "aix",
     target_os = "haiku",
     target_os = "solaris",
+    target_os = "nto",
 )))]
 pub const B4000000: Speed = c::B4000000;
 
@@ -650,6 +698,7 @@ pub const CBAUD: Tcflag = c::CBAUD;
     target_os = "aix",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "nto",
 )))]
 pub const CBAUDEX: Tcflag = c::CBAUDEX;
 
@@ -661,6 +710,7 @@ pub const CBAUDEX: Tcflag = c::CBAUDEX;
     target_os = "emscripten",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "nto",
 )))]
 pub const CIBAUD: Tcflag = c::CIBAUD;
 
@@ -678,11 +728,12 @@ pub const CIBAUD: Tcflag = 0o77600000;
     target_os = "emscripten",
     target_os = "haiku",
     target_os = "redox",
+    target_os = "nto"
 )))]
 pub const CMSPAR: Tcflag = c::CMSPAR;
 
 /// `CRTSCTS`
-#[cfg(not(any(target_os = "aix", target_os = "redox")))]
+#[cfg(not(any(target_os = "aix", target_os = "redox", target_os = "nto")))]
 pub const CRTSCTS: Tcflag = c::CRTSCTS;
 
 /// `XCASE`
@@ -694,7 +745,7 @@ pub const XCASE: Tcflag = c::XCASE;
 pub const ECHOCTL: Tcflag = c::ECHOCTL;
 
 /// `ECHOPRT`
-#[cfg(not(any(target_os = "redox")))]
+#[cfg(not(any(target_os = "redox", target_os = "nto")))]
 pub const ECHOPRT: Tcflag = c::ECHOPRT;
 
 /// `ECHOKE`
@@ -702,15 +753,20 @@ pub const ECHOPRT: Tcflag = c::ECHOPRT;
 pub const ECHOKE: Tcflag = c::ECHOKE;
 
 /// `FLUSHO`
-#[cfg(not(any(target_os = "redox")))]
+#[cfg(not(any(target_os = "redox", target_os = "nto")))]
 pub const FLUSHO: Tcflag = c::FLUSHO;
 
 /// `PENDIN`
-#[cfg(not(any(target_os = "redox")))]
+#[cfg(not(any(target_os = "redox", target_os = "nto")))]
 pub const PENDIN: Tcflag = c::PENDIN;
 
 /// `EXTPROC`
-#[cfg(not(any(target_os = "aix", target_os = "haiku", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "aix",
+    target_os = "haiku",
+    target_os = "redox",
+    target_os = "nto"
+)))]
 pub const EXTPROC: Tcflag = c::EXTPROC;
 
 /// `XTABS`

--- a/src/fs/abs.rs
+++ b/src/fs/abs.rs
@@ -8,6 +8,7 @@ use crate::ffi::{CStr, CString};
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 use crate::fs::StatFs;
 #[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "wasi")))]
@@ -235,6 +236,7 @@ pub fn access<P: path::Arg>(path: P, access: Access) -> io::Result<()> {
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 #[inline]
 pub fn statfs<P: path::Arg>(path: P) -> io::Result<StatFs> {

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -28,6 +28,7 @@ pub use backend::fs::types::Stat;
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 pub use backend::fs::types::StatFs;
 
@@ -165,6 +166,7 @@ pub fn fstat<Fd: AsFd>(fd: Fd) -> io::Result<Stat> {
     target_os = "netbsd",
     target_os = "redox",
     target_os = "wasi",
+    target_os = "nto",
 )))]
 #[inline]
 pub fn fstatfs<Fd: AsFd>(fd: Fd) -> io::Result<StatFs> {

--- a/src/io/dup.rs
+++ b/src/io/dup.rs
@@ -111,7 +111,7 @@ pub fn dup2<Fd: AsFd>(fd: Fd, new: &mut OwnedFd) -> io::Result<()> {
 /// [NetBSD]: https://man.netbsd.org/dup3.2
 /// [OpenBSD]: https://man.openbsd.org/dup3.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=dup3&section=3
-#[cfg(not(any(target_os = "aix", target_os = "wasi")))]
+#[cfg(not(any(target_os = "aix", target_os = "wasi", target_os = "nto")))]
 #[inline]
 pub fn dup3<Fd: AsFd>(fd: Fd, new: &mut OwnedFd, flags: DupFlags) -> io::Result<()> {
     backend::io::syscalls::dup3(fd.as_fd(), new, flags)

--- a/src/io/read_write.rs
+++ b/src/io/read_write.rs
@@ -185,7 +185,12 @@ pub fn writev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
 /// [OpenBSD]: https://man.openbsd.org/preadv.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=preadv&section=2
 /// [illumos]: https://illumos.org/man/2/preadv
-#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "solaris")))]
+#[cfg(not(any(
+    target_os = "haiku",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "nto"
+)))]
 #[inline]
 pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
     backend::io::syscalls::preadv(fd.as_fd(), bufs, offset)
@@ -212,7 +217,12 @@ pub fn preadv<Fd: AsFd>(fd: Fd, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io:
 /// [OpenBSD]: https://man.openbsd.org/pwritev.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pwritev&section=2
 /// [illumos]: https://illumos.org/man/2/pwritev
-#[cfg(not(any(target_os = "haiku", target_os = "redox", target_os = "solaris")))]
+#[cfg(not(any(
+    target_os = "haiku",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "nto",
+)))]
 #[inline]
 pub fn pwritev<Fd: AsFd>(fd: Fd, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
     backend::io::syscalls::pwritev(fd.as_fd(), bufs, offset)

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -91,7 +91,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 /// [OpenBSD]: https://man.openbsd.org/pipe2.2
 /// [DragonFly BSD]: https://man.dragonflybsd.org/?command=pipe2&section=2
 /// [illumos]: https://illumos.org/man/2/pipe2
-#[cfg(not(any(apple, target_os = "aix", target_os = "haiku")))]
+#[cfg(not(any(apple, target_os = "aix", target_os = "haiku", target_os = "nto")))]
 #[inline]
 #[doc(alias = "pipe2")]
 pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -54,7 +54,8 @@ pub enum Signal {
                 target_arch = "mips",
                 target_arch = "mips64",
                 target_arch = "sparc",
-                target_arch = "sparc64"
+                target_arch = "sparc64",
+                target_os = "nto",
             ),
         )
     )))]
@@ -149,6 +150,7 @@ impl Signal {
                 solarish,
                 target_os = "aix",
                 target_os = "haiku",
+                target_os = "nto",
                 all(
                     linux_kernel,
                     any(

--- a/src/termios/constants.rs
+++ b/src/termios/constants.rs
@@ -30,35 +30,73 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
         backend::termios::types::B57600 => Some(57600),
         #[cfg(not(target_os = "aix"))]
         backend::termios::types::B115200 => Some(115_200),
-        #[cfg(not(target_os = "aix"))]
+        #[cfg(not(any(target_os = "aix", target_os = "nto")))]
         backend::termios::types::B230400 => Some(230_400),
         #[cfg(not(any(
             apple,
             target_os = "aix",
             target_os = "dragonfly",
             target_os = "haiku",
-            target_os = "openbsd"
+            target_os = "openbsd",
+            target_os = "nto",
         )))]
         backend::termios::types::B460800 => Some(460_800),
-        #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+        #[cfg(not(any(
+            bsd,
+            solarish,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "nto",
+        )))]
         backend::termios::types::B500000 => Some(500_000),
-        #[cfg(not(any(bsd, solarish, target_os = "aix", target_os = "haiku")))]
+        #[cfg(not(any(
+            bsd,
+            solarish,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "nto",
+        )))]
         backend::termios::types::B576000 => Some(576_000),
         #[cfg(not(any(
             apple,
             target_os = "aix",
             target_os = "dragonfly",
             target_os = "haiku",
-            target_os = "openbsd"
+            target_os = "openbsd",
+            target_os = "nto",
         )))]
         backend::termios::types::B921600 => Some(921_600),
-        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+        #[cfg(not(any(
+            bsd,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "solaris",
+            target_os = "nto",
+        )))]
         backend::termios::types::B1000000 => Some(1_000_000),
-        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+        #[cfg(not(any(
+            bsd,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "solaris",
+            target_os = "nto",
+        )))]
         backend::termios::types::B1152000 => Some(1_152_000),
-        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+        #[cfg(not(any(
+            bsd,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "solaris",
+            target_os = "nto",
+        )))]
         backend::termios::types::B1500000 => Some(1_500_000),
-        #[cfg(not(any(bsd, target_os = "aix", target_os = "haiku", target_os = "solaris")))]
+        #[cfg(not(any(
+            bsd,
+            target_os = "aix",
+            target_os = "haiku",
+            target_os = "solaris",
+            target_os = "nto",
+        )))]
         backend::termios::types::B2000000 => Some(2_000_000),
         #[cfg(not(any(
             target_arch = "sparc",
@@ -67,6 +105,7 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
             target_os = "aix",
             target_os = "haiku",
             target_os = "solaris",
+            target_os = "nto",
         )))]
         backend::termios::types::B2500000 => Some(2_500_000),
         #[cfg(not(any(
@@ -76,6 +115,7 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
             target_os = "aix",
             target_os = "haiku",
             target_os = "solaris",
+            target_os = "nto",
         )))]
         backend::termios::types::B3000000 => Some(3_000_000),
         #[cfg(not(any(
@@ -85,6 +125,7 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
             target_os = "aix",
             target_os = "haiku",
             target_os = "solaris",
+            target_os = "nto",
         )))]
         backend::termios::types::B3500000 => Some(3_500_000),
         #[cfg(not(any(
@@ -94,6 +135,7 @@ pub fn speed_value(speed: backend::termios::types::Speed) -> Option<u32> {
             target_os = "aix",
             target_os = "haiku",
             target_os = "solaris",
+            target_os = "nto",
         )))]
         backend::termios::types::B4000000 => Some(4_000_000),
         _ => None,

--- a/src/termios/mod.rs
+++ b/src/termios/mod.rs
@@ -1,6 +1,6 @@
 //! Terminal I/O stream operations.
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "nto")))]
 mod cf;
 #[cfg(not(target_os = "wasi"))]
 mod constants;
@@ -11,7 +11,7 @@ mod tc;
 #[cfg(not(windows))]
 mod tty;
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "nto")))]
 pub use cf::*;
 #[cfg(not(target_os = "wasi"))]
 pub use constants::*;

--- a/src/termios/tty.rs
+++ b/src/termios/tty.rs
@@ -3,7 +3,7 @@
 use crate::backend;
 use backend::fd::AsFd;
 #[cfg(feature = "procfs")]
-#[cfg(not(any(target_os = "fuchsia", target_os = "wasi")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "wasi", target_os = "nto")))]
 use {
     crate::ffi::CString, crate::io, crate::path::SMALL_PATH_BUFFER_SIZE, alloc::vec::Vec,
     backend::fd::BorrowedFd,

--- a/src/ugid.rs
+++ b/src/ugid.rs
@@ -78,14 +78,22 @@ impl Gid {
 // Return the raw value of the IDs. In case of `None` it returns `u32::MAX`
 // since it has the same bit pattern as `-1` indicating no change to the
 // owner/group ID.
+// QNX Neutrino (nto) uses i32 values, but only positive values should be used, see e.g.:
+// https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/setuid.html
 pub(crate) fn translate_fchown_args(owner: Option<Uid>, group: Option<Gid>) -> (u32, u32) {
     let ow = match owner {
+        #[cfg(not(target_os = "nto"))]
         Some(o) => o.as_raw(),
+        #[cfg(target_os = "nto")]
+        Some(o) => o.as_raw() as u32,
         None => u32::MAX,
     };
 
     let gr = match group {
+        #[cfg(not(target_os = "nto"))]
         Some(g) => g.as_raw(),
+        #[cfg(target_os = "nto")]
+        Some(g) => g.as_raw() as u32,
         None => u32::MAX,
     };
 

--- a/tests/fs/file.rs
+++ b/tests/fs/file.rs
@@ -100,6 +100,7 @@ fn test_file() {
         target_os = "netbsd",
         target_os = "redox",
         target_os = "wasi",
+        target_os = "nto",
     )))]
     {
         let statfs = rustix::fs::fstatfs(&file).unwrap();

--- a/tests/fs/futimens.rs
+++ b/tests/fs/futimens.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "nto")))]
 #[test]
 fn test_futimens() {
     use rustix::fs::{fstat, futimens, openat, Mode, OFlags, Timespec, Timestamps, CWD};

--- a/tests/fs/statfs.rs
+++ b/tests/fs/statfs.rs
@@ -39,7 +39,7 @@ fn test_statfs_abi() {
     assert_eq!(NFS_SUPER_MAGIC, 0x0000_6969);
 }
 
-#[cfg(not(any(solarish, target_os = "netbsd")))]
+#[cfg(not(any(solarish, target_os = "netbsd", target_os = "nto")))]
 #[test]
 fn test_statfs() {
     let statfs = rustix::fs::statfs("Cargo.toml").unwrap();
@@ -49,7 +49,7 @@ fn test_statfs() {
     // that.
 }
 
-#[cfg(not(any(solarish, target_os = "netbsd")))]
+#[cfg(not(any(solarish, target_os = "netbsd", target_os = "nto")))]
 #[test]
 fn test_fstatfs() {
     let file = std::fs::File::open("Cargo.toml").unwrap();

--- a/tests/fs/utimensat.rs
+++ b/tests/fs/utimensat.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi", target_os = "nto")))]
 #[test]
 fn test_utimensat() {
     use rustix::fs::{openat, statat, utimensat, AtFlags, Mode, OFlags, Timespec, Timestamps, CWD};

--- a/tests/fs/y2038.rs
+++ b/tests/fs/y2038.rs
@@ -5,7 +5,7 @@
 #[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "nto")))]
 #[test]
 fn test_y2038_with_utimensat() {
     use rustix::fs::{
@@ -98,7 +98,7 @@ fn test_y2038_with_utimensat() {
 #[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "nto")))]
 #[test]
 fn test_y2038_with_futimens() {
     use rustix::fs::{
@@ -191,6 +191,7 @@ fn test_y2038_with_futimens() {
 #[cfg(not(all(target_env = "musl", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
 #[cfg(not(all(target_os = "emscripten", target_pointer_width = "32")))]
+#[cfg(not(target_os = "nto"))]
 #[test]
 fn test_y2038_with_futimens_and_stat() {
     use rustix::fs::{fstat, futimens, open, stat, Mode, OFlags, Timespec, Timestamps};

--- a/tests/io/read_write.rs
+++ b/tests/io/read_write.rs
@@ -4,6 +4,7 @@ use std::io::{IoSlice, IoSliceMut};
 #[cfg(feature = "fs")]
 #[cfg(not(target_os = "solaris"))] // no preadv/pwritev
 #[cfg(not(target_os = "haiku"))] // no preadv/pwritev
+#[cfg(not(target_os = "nto"))] // no preadv/pwritev
 #[test]
 fn test_readwrite_pv() {
     use rustix::fs::{openat, Mode, OFlags, CWD};


### PR DESCRIPTION
Dear @gh-tr, @samkearney and @Tom-Goring,

Before I make this PR public, feel free to have a look at these changes. They are required to make `rustix`, `nix`, `clap-4.2` and `ctrlc` compile.